### PR TITLE
attempt to fix 404 page on nested routes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Moonbeam Docs
-site_url: https://docs.moonbeam.network
+site_url: https://docs.moonbeam.network/
 home_url: https://moonbeam.network
 site_dir: /var/www/moonbeam-docs-static
 docs_dir: moonbeam-docs


### PR DESCRIPTION
If you go to https://docs.moonbeam.network/node-operators you'll see a normal 404 page, then if you go to https://docs.moonbeam.network/node-operators/networks you'll see a distorted 404 page.

Unfortunately, this is a difficult problem to debug and fix because the problem doesn't exist locally, only on production. So, I had no way to verify if this works or not. It didn't break anything locally, so I don't think it would break anything on production but I am not sure. If it doesn't work, we can just revert this commit. 🤷‍♀️ 

See [this comment](https://github.com/squidfunk/mkdocs-material/issues/853#issuecomment-414696167) from the owner of the mkdocs theme we are using. Basically he is saying that if we aren't using an absolute path the path won't resolve correctly for subdirectories and can cause the distorted 404 page we see on nested routes. So this PR just updates the path to be absolute!