### PR TITLE
use custom js to expand nav items

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ copyright: © 2021 PureStake, Inc. All Rights Reserved.
 #repo_name: PureStake/moonbeam-docs
 #repo_url: https://github.com/PureStake/moonbeam-docs
 #edit_uri: ""
-extra_javascript: [js/connectMetaMask.js, js/errorModal.js]
+extra_javascript: [js/connectMetaMask.js, js/errorModal.js, js/expandNav.js]
 theme: 
   name: material
   custom_dir: material-overrides
@@ -15,6 +15,8 @@ theme:
   logo:  /assets/images/Moonbeam-Favicon-50.png
   font:
     text: Open Sans
+  features:
+    - navigation.tabs
 markdown_extensions:
   - codehilite
   - meta
@@ -78,9 +80,6 @@ extra:
     - icon: fontawesome/brands/telegram-plane
       link: https://t.me/Moonbeam_Official
       name: Telegram
-    - icon: fontawesome/solid/envelope
-      link: https://moonbeam.network/newsletter/ 
-      name: Email Newsletter
     - icon: fontawesome/brands/github
       link: https://github.com/PureStake/moonbeam
       name: GitHub


### PR DESCRIPTION
This goes with [moonbeam-docs PR# 81](https://github.com/PureStake/moonbeam-docs/pull/81). 

The mkdocs one-liner is not working, it's not due to `awesome-pages` plugin, it's not due to `extra_javascript` field... I didn't want to spend a whole lot of time on this so I am ultimately not sure why it isn't working. In my research I came across [this issue](https://github.com/squidfunk/mkdocs-material/issues/767) in the mkdocs-material repo. Before `navigation.expand` was a thing, someone had written some custom javascript to handle it, which actually works. So I just decided to run with that... there is sometimes a bit of a lag in the expansion but I don't think it's bothersome, but let me know if you think otherwise! 