### PR TITLE
fix select dropdown so it has consistent appearance across operating systems

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -316,14 +316,64 @@ p.md-footer-connect {
    font-size: .9em;
 }
 
-.language-select {
+/* Language Dropdown Styling */
+.select-wrapper {
    font-family: "Open Sans";
    font-size: .7rem;
    color: white;
-   background-color: transparent;
-   border: none;
-   margin: .5rem 0 .5rem 1rem;
+   background-color: #171e43;
+   margin:0 auto;
+   max-width:225px;
+   padding:1rem;
+   position:relative;
+   z-index:3;
+   display: flex;
+   justify-content: flex-end;
+   padding-right: 2rem;
 }
-.language-select:focus-visible {
-   outline: none;
+.select-wrapper::after {
+   border-color: white transparent;
+   border-style:solid;
+   border-width:6px 6px 0;
+   content:"";
+   height:0;
+   margin-top:-4px;
+   position:absolute;
+   right:1rem;
+   top:50%;
+   width:0;
+}
+.select-wrapper .language-select {
+   background: #171e43;
+   box-shadow:3px 3px 3px rgba(0,0,0,.2);
+   display:none;
+   left:0;
+   list-style:none;
+   margin-top:0;
+   opacity:0;
+   padding-left:0;
+   pointer-events:none;
+   position:absolute;
+   right:0;
+   top:100%;
+   z-index:2;
+}
+.select-wrapper .language-select li {
+   color: white;
+   display:block;
+   padding:1rem;
+   text-decoration:none; 
+}
+.select-wrapper .language-select li:hover {
+   background-color: white;
+   color:#171e43;
+}
+.select-wrapper.active::after {
+   border-width:0 6px 6px;
+}
+.select-wrapper.active .language-select {
+   display:block;
+   opacity:1;
+   pointer-events:auto;
+   opacity: .9;
 }

--- a/material-overrides/partials/header.html
+++ b/material-overrides/partials/header.html
@@ -42,11 +42,12 @@
       {% include "partials/source.html" %}
     </div>
     {% endif %}
-    <div>
-      <select class="language-select">
-        <option class="en" value="en">English</option>
-        <option class="cn" value="cn">Chinese</option>
-      </select>
+    <div class="select-wrapper">
+      <span class="select-label"></span>
+      <ul class="language-select">
+        <li class="en" value="en">English</option>
+        <li class="cn" value="cn">中文</option>
+      </ul>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
I was previously using a HTML Select element, however there are limited options when styling selects as most of the styling is dictated by the user's operating system. There are a couple answers to [this stackoverflow thread](https://stackoverflow.com/questions/7208786/how-to-style-the-option-of-an-html-select-element) that explain it well.

So I created a custom select dropdown using `ul` and `li`s and a bunch of css so that the dropdown will look good and consistent across browsers and operating systems. 

This goes with [moonbeam-docs PR #86](https://github.com/PureStake/moonbeam-docs/pull/86)