### PR TITLE
Update faucet redirect

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ plugins:
            'getting-started/local-node/ethers-js/ethers-contract.md': 'getting-started/local-node/deploy-contract.md'
            'getting-started/testnet/pubsub.md': 'integrations/pubsub.md'
            'getting-started/testnet/precompiles.md': 'integrations/precompiles.md'
+           'getting-started/testnet/faucet.md':'getting-started/moonbase/faucet.md'
            'integrations/metamask.md': 'integrations/wallets/metamask.md'
            'integrations/polkadotjs.md': 'integrations/wallets/polkadotjs.md'
            'integrations/jslibraries/web3js.md': 'integrations/ethlibraries/web3js.md'


### PR DESCRIPTION
If you search Google for "Moonbase Alpha faucet" the first result is the old page which yields a 404. -> This should redirect to correct page.