### PR TITLE
add default style and fix redirects index

### DIFF
--- a/scripts/calculate-redirects.py
+++ b/scripts/calculate-redirects.py
@@ -153,7 +153,7 @@ print("🔧 Modifying existing redirects...")
 print("➕ Creating new redirects...")
 
 mkdocs_yaml = yaml.unsafe_load(open("mkdocs.yml", "r"))
-prev_mapping = mkdocs_yaml["plugins"][3]["redirects"]["redirect_maps"]
+prev_mapping = mkdocs_yaml["plugins"][2]["redirects"]["redirect_maps"]
 prev_values = list(prev_mapping.values())
 prev_keys = list(prev_mapping.keys())
 
@@ -167,9 +167,9 @@ new_dict = {}
 for redirect in redirect_map:
   new_dict[redirect.previous_path] = redirect.current_path
 
-mkdocs_yaml["plugins"][3]["redirects"]["redirect_maps"] = new_dict
+mkdocs_yaml["plugins"][2]["redirects"]["redirect_maps"] = new_dict
 with open("mkdocs.yml", "w") as f:
-    yaml.dump(mkdocs_yaml, f, sort_keys=False, allow_unicode=True, indent=2)
+    yaml.dump(mkdocs_yaml, f, sort_keys=False, allow_unicode=True, default_style="'", indent=2)
 
 print("✅ Successfully updated the mkdocs.yml file with new redirects")
 


### PR DESCRIPTION
Add a default style when dumping the yaml, this wraps everything in strings so the redirects still work. I didn't notice before but there was an error getting buried in my terminal logs due to the redirects not being wrapped in strings. Ended up noticing this problem today starting from a fresh instance, `mkdocs-serve` would error and not build the site.

Also fix the redirect index since it should be `2`... if you look at the `mkdocs.yml` `redirects` is in the 2nd index position