### PR TITLE
fix styling for smaller screens

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -451,11 +451,12 @@ p.md-footer-connect {
   flex-direction: column;
   margin: .5em;
 }
-.hero {
+.hero-img {
   width: 90em;
 }
 .hero-column {
   margin-right: 3em;
+  margin-left: 0;
 }
 h1.hero-title {
   font-weight: 400;
@@ -574,6 +575,56 @@ a.in-this-section-link {
   line-height: 1.2em;
   margin-left: .5em;
   align-self: center;
+}
+@media screen and (max-width: 76.1875em) {
+  .card {
+    flex-wrap: wrap;
+    max-width: 40%;
+  }
+  .cards {
+    flex-wrap: wrap;
+  }
+  .row.hero, .row.cards {
+    width: 90%;
+    margin: auto;
+  }
+  .hero-img {
+    margin: auto;
+  }
+  .row.hero-buttons {
+    flex-wrap: wrap;
+    margin-top: 0;
+  }
+  .row.hero-buttons > a {
+    margin: .25em 0;
+  }
+  .card:first-child, .hero-column {
+    margin-left: .75em;
+  }
+  .card:last-child {
+    margin-right: .75em;
+  }
+  h1.hero-title {
+    margin-top: 0;
+  }
+}
+@media screen and (max-width: 48.125em) {
+  .hero-img {
+    display: none;
+  }
+  .card {
+    max-width: unset;
+    margin: .5em 0;
+  }
+  .hero-column, .card:first-child, .card:last-child {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+@media screen and (max-width: 30em) {
+  .md-header-nav__ellipsis.md-ellipsis {
+    display: none;
+  }
 }
 
 /* Styling for section headers on left hand side navigation menu */

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <div class="home">
-  <div class="row">
+  <div class="row hero">
     <div class="column hero-column">
       <h1 class="hero-title">Moonbeam Network Resources & Documentation</h1>
       <h3 class="hero-info">Moonbeam combines the best of both worlds: the familiar and easy-to-use tooling of Ethereum
@@ -29,10 +29,10 @@
       </div>
     </div>
     <div class="column">
-      <img class="hero" src="{{ 'assets/images/hero.png' }}" />
+      <img class="hero-img" src="{{ 'assets/images/hero.png' }}" />
     </div>
   </div>
-  <div class="row">
+  <div class="row cards">
     <div class="card">
       <div>
         <img src="{{ 'assets/images/builders.png' }}" />


### PR DESCRIPTION
add styles for smaller screens! gets rid of the main hero image on smaller screens and displays the cards in a single column 
<img width="436" alt="Screen Shot 2021-09-03 at 2 55 46 PM" src="https://user-images.githubusercontent.com/26533957/132064878-8d541085-c202-49e7-8c4e-9d93f164e447.png">
