### PR TITLE
add quick ref section to home page with canonical contracts button

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -598,6 +598,9 @@ p.quick-ref-title {
   margin-top: 0;
   margin-bottom: 2em;
 }
+.quick-ref-buttons a {
+  margin-right: .3em;
+}
 .md-button.quick-ref-button:hover, .md-button.quick-ref-button:focus {
   background-color: lightgrey;
   border-color: lightgrey;

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -31,7 +31,7 @@
         <p class="quick-ref-title">Quick References</p>
         <div class="quick-ref-buttons">
           <a href="{{ config.site_url }}builders/get-started/eth-compare/">
-            <button class="md-button quick-ref-button">Ethereum Comparison</button>
+            <button class="md-button quick-ref-button">Moonbeam vs Ethereum</button>
           </a>
           <a href="{{ config.site_url }}builders/interact/canonical-contracts/">
             <button class="md-button quick-ref-button">Canonical Contracts</button>


### PR DESCRIPTION
This PR adds a quick reference section with grey buttons, currently there is only one for canonical contracts. But I was thinking once we have an API providers page, we could add a button for that too.

While working on this, I noticed a bug in the spacing of the section index page cards, so I fixed some css for that too.

The home page now looks like this:

<img width="1733" alt="Screen Shot 2021-09-16 at 5 23 10 PM" src="https://user-images.githubusercontent.com/26533957/133687689-dd3ea0a8-425b-4f3e-ae13-1422941b7177.png">
