### PR TITLE
update modal scroll styles so scrollbars don't show up for windows users

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -285,7 +285,7 @@ a:hover {
   margin: 15% auto;
   font-size: 2em;
   padding: 1em;
-  overflow: scroll;
+  overflow: auto;
 }
 .close-modal {
   font-size: 2em;


### PR DESCRIPTION
when `overflow:scroll` is set scrollbars show up everywhere for windows users... and I as a mac user for many years wasn't aware of this because they just don't show up unless they need to haha. 

I came across this article which provides more insight around what happened: https://kilianvalkhof.com/2021/css-html/you-want-overflow-auto-not-overflow-scroll/

TLDR: 
`overflow: scroll`: Always show a scroll bar.
`overflow: auto`: Show a scroll bar when needed.

We'll probably want a windows user (Katie?) to check this out on staging before publishing, just to make sure since I can't see the problem in the first place 😅 