### PR TITLE
add redirect for debug trace page

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -139,6 +139,7 @@ docs_dir: moonbeam-docs-cn
         'dapps-list/oracles/chainlink.md': 'learn/dapps-list/oracles/chainlink.md'
         'dapps-list/oracles/dia.md': 'learn/dapps-list/oracles/dia.md'
         'builders/interact/metamask-dapp.md': 'https://medium.com/moonbeam-network/integrate-metamask-into-a-dapp-ea7528c5a786'
+        'builders/tools/debug-trace.md': 'node-operators/networks/debug-trace.md'
 
   - 'macros':
       'include_yaml':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@
         'dapps-list/oracles/chainlink.md': 'learn/dapps-list/oracles/chainlink.md'
         'dapps-list/oracles/dia.md': 'learn/dapps-list/oracles/dia.md'
         'builders/interact/metamask-dapp.md': 'https://medium.com/moonbeam-network/integrate-metamask-into-a-dapp-ea7528c5a786'
+        'builders/tools/debug-trace.md': 'node-operators/networks/debug-trace.md'
   - 'macros':
       'include_yaml':
         - 'moonbeam-docs/variables.yml'


### PR DESCRIPTION
Just adds a redirect for the debug trace page since it's now moved to Node Operators > Networks