### PR TITLE
update redirects to reflect recent changes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@
         'builders/tools/remix.md': 'builders/tools/eth-dev-env/remix.md'
         'builders/tools/truffle.md': 'builders/tools/eth-dev-env/truffle.md'
         'builders/tools/waffle.md': 'builders/tools/eth-dev-env/waffle.md'
+        'integrations/bridges/ethereum/chainbridge.md': 'builders/integrations/bridges/eth/chainbridge.md'
   - 'macros':
       'include_yaml':
         - 'moonbeam-docs/variables.yml'


### PR DESCRIPTION
update redirects to reflect recent changes to the English repo, which includes the creation of the new Eth Dev Environments section

I also missed a couple redirects from moving the precompiles so this addresses that as well

Goes along with this PR 👉  https://github.com/PureStake/moonbeam-docs/pull/188