### PR TITLE
SEO updates for metadata

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -5,6 +5,13 @@
     <link rel="stylesheet" href="{{ '/assets/stylesheets/moonbeam.css' | url }}">
 {% endblock %}
 
+{% block site_meta %}
+    {{ super() }}
+    {% if page and page.meta.keywords %}
+      <meta name="keywords" content="{{ page.meta.keywords }}">
+    {% endif %}
+{% endblock %}
+
 {%- block htmltitle -%} 
    {%- if page.is_homepage -%} 
      <title>Documentation for the Moonbeam Smart Contract Platform</title> 
@@ -16,5 +23,6 @@
      <title>{{ config.site_name }}</title> 
    {%- endif -%} 
  {%- endblock -%} 
+
 
  


### PR DESCRIPTION
This PR updates how metadata is handled... it uses the pages meta title instead of the page title and also adds support for meta keywords

Goes with https://github.com/PureStake/moonbeam-docs/pull/288