### PR TITLE
update & add chainbridge redirects for EN site

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -116,6 +116,7 @@ docs_dir: moonbeam-docs-cn
         'learn/dapps-list/bridges/eth/index.md': 'learn/dapps-list/index.md'
         'learn/dapps-list/bridges/eth/chainbridge.md': 'builders/integrations/bridges/chainbridge.md'
         'builders/integrations/bridges/eth/chainbridge.md': 'builders/integrations/bridges/chainbridge.md'
+        'builders/integrations/bridges/eth/index.md': 'builders/integrations/bridges/index.md'
         'learn/dapps-list/defi/index.md': 'learn/dapps-list/index.md'
         'learn/dapps-list/defi/sushiswap.md': 'learn/dapps-list/index.md'
         'learn/dapps-list/defi/amaralend.md': 'learn/dapps-list/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@
               'staking/overview.md': 'learn/features/staking.md'
               'treasury/overview.md': 'learn/features/treasury.md'
               'builders/integrations/bridges/eth/chainbridge.md': 'builders/integrations/bridges/chainbridge.md'
+              'builders/integrations/bridges/eth/index.md': 'builders/integrations/bridges/index.md'
               'dapps-list/bridges/chainbridge.md': 'builders/integrations/bridges/chainbridge.md'
               'dapps-list/defi/sushiswap.md': 'learn/dapps-list/index.md'
               'dapps-list/metatransactions/biconomy.md': 'learn/dapps-list/index.md'


### PR DESCRIPTION
Update the redirects for the english mkdocs.yml file to reflect changes made to the removal of the `builders/integrations/bridges/eth` directory