### PR TITLE
remove meta description from home.html

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -6,12 +6,6 @@
 {%- endif -%}
 {% endblock %}
 
-{% block site_meta %}
-{%- if page.is_homepage -%}
-<meta name="description" content="Dive into the tools, integrations, and comprehensive tutorials to start using and building on Moonbeam, an Ethereum-compatible parachain on Polkadot.">
-{%- endif -%}
-{% endblock %}
-
 {% block content %}
 <div class="home">
   <div class="row hero">


### PR DESCRIPTION
The addition of the meta description on the home.html page caused the mobile view to be rendered incorrectly. So removing it from the home.html page and adding it to the index.html page in the moonbeam-docs repo instead