### PR TITLE
remove script on orbiters page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@
     - 'js/networkModal.js'
     - 'js/handleLanguageChange.js'
     - 'js/renderSubsections.js'
-    - 'js/updateTabDefault.js'
 'theme':
     'name': 'material'
     'custom_dir': 'material-overrides'


### PR DESCRIPTION
Removes the `updateTabDefault.js` script which was previously used to default to the Moonriver tab on the Orbiters page. Now that the program is being rolled out to Moonbeam, Moonbeam can be the default.