### PR TITLE
add config to disable the git-revision-date-localized plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@
     - 'search'
     - 'awesome-pages'
     - 'git-revision-date-localized':
+        'enabled': !ENV [ENABLED_GIT_REVISION_DATE, True]
         'enable_creation_date': !!bool 'true'
     - 'redirects':
           'redirect_maps':

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,15 @@ mkdocs serve
 
 After a successful build, the site should be available at `http://127.0.0.1:8000`
 
+## Disable the Git Dates Plugin
+
+The `git-revision-date-localized` plugin pulls the date of the last git modification of a page. When developing locally, this can slow down your development process, as every time a change is made to a page, the plugin checks for the latest dates for all the pages. To avoid this, you can change your start-up command to disable the plugin by running:
+
+```bash
+export ENABLED_GIT_REVISION_DATE=false
+mkdocs serve
+```
+
 ## Other Notes
 
 https://www.mkdocs.org/


### PR DESCRIPTION
This PR adds the `enabled` config to the git-revision-date-localized plugin so that it can be disabled on local development. @albertov19 you're on windows, right? can you test this out? depending on what terminal you use, you may need to set the variable differently

windows command prompt: `set ENABLED_GIT_REVISION_DATE=false`
windows powershell: `$env:ENABLED_GIT_REVISION_DATE = "false"`

let me know I can update the readme!