### PR TITLE
add mintable xc20 redirect

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -64,6 +64,7 @@
         'builders/get-started/moonriver.md': 'builders/get-started/networks/moonriver.md'
         'builders/get-started/networks/layer2/bobabeam.md': 'builders/get-started/networks/index.md'
         'builders/interoperability/xcm/xc-integration.md': 'builders/interoperability/xcm/xc-registration/index.md'
+        'builders/interoperability/xcm/xc20/mintable-xc20.md': 'builders/interoperability/xcm/xc20/overview.md'
         'builders/xcm/index.md': 'builders/interoperability/xcm/index.md'
         'builders/xcm/overview.md': 'builders/interoperability/xcm/overview.md'
         'builders/xcm/xc20/index.md': 'builders/interoperability/xcm/xc20/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@
               'builders/get-started/networks/layer2/bobabeam.md': 'builders/get-started/networks/index.md'
               'builders/interact/hardhat.md': 'builders/build/eth-api/dev-env/hardhat.md'
               'builders/interoperability/xcm/xc-integration.md': 'builders/interoperability/xcm/xc-registration/index.md'
+              'builders/interoperability/xcm/xc20/mintable-xc20.md': 'builders/interoperability/xcm/xc20/overview.md'
               'builders/xcm/fees.md': 'builders/interoperability/xcm/fees.md'
               'builders/xcm/xc20/index.md': 'builders/interoperability/xcm/xc20/index.md'
               'builders/xcm/xc20/overview.md': 'builders/interoperability/xcm/xc20/overview.md'


### PR DESCRIPTION
Add redirects for the removed mintable XC-20 pages. It'll take users back to the XC-20 Overview page where they can check out the types of XC-20s.
Page removed in: https://github.com/moonbeam-foundation/moonbeam-docs/pull/788 and https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/358