### PR TITLE
update termynal css

### DIFF
--- a/material-overrides/assets/stylesheets/termynal.css
+++ b/material-overrides/assets/stylesheets/termynal.css
@@ -17,10 +17,10 @@
     max-width: 100%;
     background: var(--color-bg);
     color: var(--color-text);
-    font-size: 12px;
+    font-size: 13px;
     font-family: 'Fira Mono', Consolas, Menlo, Monaco, 'Courier New', Courier, monospace;
     border-radius: 4px;
-    padding: 55px 45px 35px;
+    padding: 50px 30px 20px;
     position: relative;
     -webkit-box-sizing: border-box;
             box-sizing: border-box;
@@ -65,12 +65,15 @@
 
 [data-ty="input"]:before,
 [data-ty-prompt]:before {
-    margin-right: 0.75em;
     color: #53cbc9;
+    content: 'moonbeam@ubuntu-jammy:';
+    size: 14px;
 }
 
-[data-ty="input"]:before {
-    content: 'moonbeam@ubuntu-jammy:~$';
+.file-path:before {
+    content: '~$';
+    color: #E1147B;
+    margin-right: 0.75em;
 }
 
 [data-ty][data-ty-prompt]:before {


### PR DESCRIPTION
This PR applies the same changes we made in the Tanssi repo. It separates the system name (`moonbeam@ubuntu-jammy`) and the file path (`~$`) 

<img width="753" alt="Screenshot 2024-01-14 at 11 11 39 PM" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/d2f3d9fe-b37e-491f-bcd3-b54d36d98158">

Goes with this PR: https://github.com/moonbeam-foundation/moonbeam-docs/pull/846