### PR TITLE
add the minify plugin

### DIFF
--- a/material-overrides/404.html
+++ b/material-overrides/404.html
@@ -2,10 +2,6 @@
   This file was automatically generated - do not edit
 -#}
 {% extends "base.html" %}
-{% block styles %}
-	{{ super() }}
-  <link rel="stylesheet" href="{{ '/assets/stylesheets/moonbeam.css' | url }}">
-{% endblock %}
 
 {% block fonts %}
   {{ super() }}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{% block styles %}
-	{{ super() }}
-  <link rel="stylesheet" href="{{ '/assets/stylesheets/moonbeam.css' | url }}">
-{% endblock %}
-
 {% block fonts %}
   {{ super() }}
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/mkdocs-cn/material-overrides/404.html
+++ b/mkdocs-cn/material-overrides/404.html
@@ -2,10 +2,6 @@
   This file was automatically generated - do not edit
 -#}
 {% extends "base.html" %}
-{% block styles %}
-	{{ super() }}
-  <link rel="stylesheet" href="{{ '/assets/stylesheets/moonbeam.css' | url }}">
-{% endblock %}
 
 {% block fonts %}
   {{ super() }}

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -15,6 +15,7 @@
   - 'js/initKapaWidget.js'
   - 'js/termynal.min.js'
 'extra_css':
+  - '/assets/stylesheets/moonbeam.css'
   - '/assets/stylesheets/termynal.css'
 'theme':
   'name': 'material'
@@ -60,6 +61,21 @@
       'exclude':
         - '.snippets/*'
       'enable_creation_date': !!bool 'true'
+  - 'minify':
+      'minify_html': !!bool 'true'
+      'minify_js': !!bool 'true'
+      'minify_css': !!bool 'true'
+      'js_files':
+        - 'js/connectMetaMask.js'
+        - 'js/errorModal.js'
+        - 'js/networkModal.js'
+        - 'js/handleLanguageChange.js'
+        - 'js/fixCreatedDate.js'
+        - 'js/externalLinkModal.js'
+        - 'js/initKapaWidget.js'
+      'css_files': 
+        - '/assets/stylesheets/termynal.css'
+        - '/assets/stylesheets/moonbeam.css'
   - 'redirects':
       'redirect_maps':
         'builders/build/eth-api/dev-env/truffle.md': 'builders/build/eth-api/dev-env/index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@
   - 'js/initKapaWidget.js'
   - 'js/termynal.min.js'
 'extra_css':
+  - '/assets/stylesheets/moonbeam.css'
   - '/assets/stylesheets/termynal.css'
 'theme':
   'name': 'material'
@@ -61,6 +62,21 @@
           - '.snippets/*'
         'enabled': !ENV [ENABLED_GIT_REVISION_DATE, True]
         'enable_creation_date': !!bool 'true'
+    - 'minify':
+        'minify_html': !!bool 'true'
+        'minify_js': !!bool 'true'
+        'minify_css': !!bool 'true'
+        'js_files':
+            - 'js/connectMetaMask.js'
+            - 'js/errorModal.js'
+            - 'js/networkModal.js'
+            - 'js/handleLanguageChange.js'
+            - 'js/fixCreatedDate.js'
+            - 'js/externalLinkModal.js'
+            - 'js/initKapaWidget.js'
+        'css_files': 
+            - '/assets/stylesheets/termynal.css'
+            - '/assets/stylesheets/moonbeam.css'
     - 'redirects':
           'redirect_maps':
               'builders/build/canonical-contracts/precompiles/eth-mainnet.md': 'builders/pallets-precompiles/precompiles/eth-mainnet.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ mkdocs-git-revision-date-localized-plugin==1.2.2
 mkdocs-macros-plugin==1.0.5
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.5.3
+mkdocs-minify-plugin==0.7.2
 mkdocs-redirects==1.2.1
 nltk==3.8.1
 Pillow==9.4.0


### PR DESCRIPTION
This PR adds the minify plugin, which will minify all of the HTML, CSS, and JavaScript files. In order for this to work as intended, the `moonbeam.css` file needs to be under the `extra_css` config in the `mkdocs.yml` file. With the css config updated there, we don't need to specify it in the `main.html` or `404.html` file