### PR TITLE
remove termynal js

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -13,7 +13,6 @@
   - 'js/externalLinkModal.js'
   - 'https://widget.kapa.ai/kapa-widget.bundle.js'
   - 'js/initKapaWidget.js'
-  - 'js/termynal.min.js'
 'extra_css':
   - '/assets/stylesheets/termynal.css'
 'theme':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,6 @@
   - 'js/externalLinkModal.js'
   - 'https://widget.kapa.ai/kapa-widget.bundle.js'
   - 'js/initKapaWidget.js'
-  - 'js/termynal.min.js'
 'extra_css':
   - '/assets/stylesheets/termynal.css'
 'theme':


### PR DESCRIPTION
We're not using any of the termynal animations, and, for the sake of performance, we don't need to either. So this PR removes the extra unnecessary JavaScript file.
Goes with: https://github.com/moonbeam-foundation/moonbeam-docs/pull/856