### PR TITLE
Fix the TOC shifting and emoji rendering

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -534,6 +534,12 @@ li>nav.md-nav[data-md-level="4"] ul.md-nav__list {
   color: var(--md-primary-fg-color--bright);
 }
 
+.md-nav--secondary a.md-nav__link.md-nav__link--active,
+.md-nav--secondary a.md-nav__link.md-nav__link--active:hover  {
+  margin-left: 0;
+  padding-left: 0;
+}
+
 /* Hides paragraph mark at end of anchored text */
 .md-content .headerlink {
   display: none;

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -40,6 +40,8 @@
   - 'pymdownx.snippets':
       'base_path': 'moonbeam-docs-cn/.snippets'
   - 'pymdownx.emoji':
+      'emoji_index': !!python/name:material.extensions.emoji.twemoji
+      'emoji_generator': !!python/name:material.extensions.emoji.to_svg
       'options':
         'custom_icons':
           - 'material-overrides/.icons'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,8 @@
   - 'pymdownx.snippets':
       'base_path': 'moonbeam-docs/.snippets'
   - 'pymdownx.emoji':
+      'emoji_index': !!python/name:material.extensions.emoji.twemoji
+      'emoji_generator': !!python/name:material.extensions.emoji.to_svg
       'options':
         'custom_icons':
           - 'material-overrides/.icons'


### PR DESCRIPTION
This PR fixes two things:

1. The right-hand side table of contents shifts when you click on or scroll down a page; whatever section is the active section, it shifts to the right, so it looks like its subsection when it is not. For example, the [pre-funded development accounts section](https://docs.moonbeam.network/builders/get-started/networks/moonbeam-dev/#pre-funded-development-accounts) is a main section (##) not a subsection (###)
2. Just realized that we do use emojis on the [Source Code page](https://docs.moonbeam.network/learn/platform/code/), which was an oversight on my part, as I just removed this functionality in the last dependency update 🙈