### PR TITLE
remove kapa widget script from minify list and temporarily disable the privacy plugin

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -72,7 +72,6 @@
         - 'js/handleLanguageChange.js'
         - 'js/fixCreatedDate.js'
         - 'js/externalLinkModal.js'
-        - 'js/initKapaWidget.js'
       'css_files': 
         - '/assets/stylesheets/termynal.css'
         - '/assets/stylesheets/moonbeam.css'

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -60,7 +60,7 @@
       'exclude':
         - '.snippets/*'
       'enable_creation_date': !!bool 'true'
-  - 'privacy'
+  # - 'privacy'
   - 'minify':
       'minify_html': !!bool 'true'
       'minify_js': !!bool 'true'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,6 @@
             - 'js/handleLanguageChange.js'
             - 'js/fixCreatedDate.js'
             - 'js/externalLinkModal.js'
-            - 'js/initKapaWidget.js'
         'css_files': 
             - '/assets/stylesheets/termynal.css'
             - '/assets/stylesheets/moonbeam.css'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@
           - '.snippets/*'
         'enabled': !ENV [ENABLED_GIT_REVISION_DATE, True]
         'enable_creation_date': !!bool 'true'
-    - 'privacy'
+    # - 'privacy'
     - 'minify':
         'minify_html': !!bool 'true'
         'minify_js': !!bool 'true'


### PR DESCRIPTION
This PR removes the init kapa script from the minify list. it's already been removed from the `extra_javascript` config, so just needs to be removed here too!

EDIT: this PR also removes the privacy plugin temporarily. there are some compatibility issues with some of the other changes i was making that didn't get tested and as a result broke some stuff. so I need to circle back to that later