### PR TITLE
update termynal styling to break long lines to the next line

### DIFF
--- a/material-overrides/assets/stylesheets/termynal.css
+++ b/material-overrides/assets/stylesheets/termynal.css
@@ -39,6 +39,7 @@
 [data-ty] {
     display: block;
     line-height: 1.25;
+    overflow-wrap: break-word;
 }
 
 [data-ty]:before {


### PR DESCRIPTION
This is so the text within the terminal doesn't overflow outside of the window.