### PR TITLE
make intro disclaimer text slightly smaller

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1030,6 +1030,11 @@ html .md-typeset details.function div.tabbed-set,
   margin-top: 3em;
 }
 
+.intro-disclaimer {
+  font-size: .8em;
+  font-style: italic;
+}
+
 /* Feedback widget styling */
 .md-feedback {
   margin: 1em auto 2em;


### PR DESCRIPTION
Make the intro disclaimer text slightly smaller

Before:
<img width="704" alt="Screenshot 2024-02-28 at 9 12 48 PM" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/3e548e49-6d13-45f5-994c-80d65578bf04">


After:
<img width="708" alt="Screenshot 2024-02-28 at 9 11 49 PM" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/19072359-bc68-4c20-ad6a-d1ce90d49952">

Note: the `*`s won't be there as they are displayed on the After image so please ignore those 😅 