### PR TITLE
add banner feature and info about async backing

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1769,7 +1769,7 @@ p.quick-ref-title {
 }
 
 .md-tab__list {
-  position: fixed;
+  position: absolute;
   background: var(--dropdown-bg-color);
   border-radius: 1em;
   z-index: 3;
@@ -1777,7 +1777,7 @@ p.quick-ref-title {
   display: none;
   margin-top: 1em;
   padding: 0;
-  top: 5em; /* Needed for Safari */
+  top: 4.75em; /* Needed for Safari */
 }
 
 .md-tabs__item--custom:hover .md-tab__list,
@@ -1858,4 +1858,13 @@ p.quick-ref-title {
   display: flex;
   justify-content: center;
   padding: 1em;
+}
+
+/* Announcement bar */
+.md-banner {
+  background-color: var(--md-footer-bg-color--dark);
+}
+
+.md-banner__inner.md-grid.md-typeset {
+  text-align: center;
 }

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -43,3 +43,8 @@
     <title>{{ config.site_name }}</title> 
   {%- endif -%} 
 {%- endblock -%} 
+
+{% block announce %}
+  <p>Block times are now 6 seconds on Moonbase Alpha thanks to asynchrounous backing!
+     Learn more about <a href="https://docs.moonbeam.network/builders/build/releases/runtime-2800/">async backing</a>.</p>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@
     - 'navigation.instant'
     - 'navigation.prune'
     - 'content.code.copy'
+    - 'announce.dismiss'
 'markdown_extensions':
   - 'codehilite'
   - 'meta'


### PR DESCRIPTION
This PR adds a banner feature to the top of the page on the docs site. I've set it up to include info on async backing and 6 second block times on moonbase alpha!

<img width="1781" alt="Screenshot 2024-03-04 at 11 28 54 PM" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/dd156827-ebce-4019-9ab9-25d7b24ec26a">

The link corresponds to a new page, which is under review in a separate PR (https://github.com/moonbeam-foundation/moonbeam-docs/pull/877)