### PR TITLE
hide the releases section from navigation

### DIFF
--- a/material-overrides/partials/nav-item.html
+++ b/material-overrides/partials/nav-item.html
@@ -60,7 +60,13 @@
         {% endif %}
         {% for nav_item in nav_item.children %}
           {% if not indexes or nav_item != indexes | first %}
-            {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% if nav_item.is_section and nav_item.children[0].url == "builders/build/releases/" %}
+              {#-
+                NOTE: In this case, we want to hide the release section on the left nav
+              -#}
+            {% else %}
+              {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% endif %}
           {% endif %}
         {% endfor %}
         </ul>

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -15,45 +15,51 @@
           <div class="subsection-wrapper">
           {% set description = "" %}
           {% for nav_item in element[1:] %}
-            {% if nav_item.is_section %}
-              {% set subsection_path = nav_item.children[0].url %}
-              {% set description = nav_item.children[0].meta.description %}
+            {% if nav_item.is_section and nav_item.children[0].url == "builders/build/releases/"%}
+              {#-
+                NOTE: In this case, we want to hide the release section from the "Build" index page
+              -#}
             {% else %}
-              {% set subsection_path = nav_item.url %}
-              {% if nav_item.meta %}
-                {% set description = nav_item.meta.description %}
-              {% endif %}
-            {% endif %}
-            {% if ".index" in page.url %}
-              {% set subsection_path = "/" + subsection_path %}
-            {% else %}
-              {% set subsection_path = subsection_path|replace(page.url, '') %}
-            {% endif %}
-
-            <div class="card">
-              <a href="{{ subsection_path }}">
-                <h2 class="title">{{ nav_item.title }}</h2> 
-                {% if not description == "" %}
-                  <p class="description">{{ description }}</p>
-                {% else %}
-                  {% if nav_item.is_link %}
-                    {% if '#' in nav_item.url %}
-                      {% set nav_item_url = nav_item.url.split('#')[0] %}
-                    {% else %}
-                      {% set nav_item_url = nav_item.url %}
-                    {% endif %}
-
-                    {% if nav_item_url.startswith('/') %}
-                      {% set nav_item_url = nav_item_url[1:] %}
-                    {% endif %}
-
-                    {% for nav_child in nav.children %}
-                      {{ find_desc_for_linked_pages(nav_child, nav_item_url, description) }}
-                    {% endfor %}
-                  {% endif %}
+              {% if nav_item.is_section %}
+                {% set subsection_path = nav_item.children[0].url %}
+                {% set description = nav_item.children[0].meta.description %}
+              {% else %}
+                {% set subsection_path = nav_item.url %}
+                {% if nav_item.meta %}
+                  {% set description = nav_item.meta.description %}
                 {% endif %}
-              </a>    
-            </div>
+              {% endif %}
+              {% if ".index" in page.url %}
+                {% set subsection_path = "/" + subsection_path %}
+              {% else %}
+                {% set subsection_path = subsection_path|replace(page.url, '') %}
+              {% endif %}
+              
+              <div class="card">
+                <a href="{{ subsection_path }}">
+                  <h2 class="title">{{ nav_item.title }}</h2> 
+                  {% if not description == "" %}
+                    <p class="description">{{ description }}</p>
+                  {% else %}
+                    {% if nav_item.is_link %}
+                      {% if '#' in nav_item.url %}
+                        {% set nav_item_url = nav_item.url.split('#')[0] %}
+                      {% else %}
+                        {% set nav_item_url = nav_item.url %}
+                      {% endif %}
+
+                      {% if nav_item_url.startswith('/') %}
+                        {% set nav_item_url = nav_item_url[1:] %}
+                      {% endif %}
+
+                      {% for nav_child in nav.children %}
+                        {{ find_desc_for_linked_pages(nav_child, nav_item_url, description) }}
+                      {% endfor %}
+                    {% endif %}
+                  {% endif %}
+                </a>    
+              </div>
+            {% endif %}
           {% endfor %}
           </div>
         {% endif %}

--- a/mkdocs-cn/material-overrides/partials/nav-item.html
+++ b/mkdocs-cn/material-overrides/partials/nav-item.html
@@ -60,7 +60,13 @@
         {% endif %}
         {% for nav_item in nav_item.children %}
           {% if not indexes or nav_item != indexes | first %}
-            {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% if nav_item.is_section and nav_item.children[0].url == "builders/build/releases/" %}
+              {#-
+                NOTE: In this case, we want to hide the release section on the left nav
+              -#}
+            {% else %}
+              {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+            {% endif %}
           {% endif %}
         {% endfor %}
         </ul>

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -15,45 +15,51 @@
           <div class="subsection-wrapper">
           {% set description = "" %}
           {% for nav_item in element[1:] %}
-            {% if nav_item.is_section %}
-              {% set subsection_path = nav_item.children[0].url %}
-              {% set description = nav_item.children[0].meta.description %}
+            {% if nav_item.is_section and nav_item.children[0].url == "builders/build/releases/"%}
+              {#-
+                NOTE: In this case, we want to hide the release section from the "Build" index page
+              -#}
             {% else %}
-              {% set subsection_path = nav_item.url %}
-              {% if nav_item.meta %}
-                {% set description = nav_item.meta.description %}
-              {% endif %}
-            {% endif %}
-            {% if ".index" in page.url %}
-              {% set subsection_path = "/" + subsection_path %}
-            {% else %}
-              {% set subsection_path = subsection_path|replace(page.url, '') %}
-            {% endif %}
-
-            <div class="card">
-              <a href="{{ subsection_path }}">
-                <h2 class="title">{{ nav_item.title }}</h2> 
-                {% if not description == "" %}
-                  <p class="description">{{ description }}</p>
-                {% else %}
-                  {% if nav_item.is_link %}
-                    {% if '#' in nav_item.url %}
-                      {% set nav_item_url = nav_item.url.split('#')[0] %}
-                    {% else %}
-                      {% set nav_item_url = nav_item.url %}
-                    {% endif %}
-
-                    {% if nav_item_url.startswith('/') %}
-                      {% set nav_item_url = nav_item_url[1:] %}
-                    {% endif %}
-
-                    {% for nav_child in nav.children %}
-                      {{ find_desc_for_linked_pages(nav_child, nav_item_url, description) }}
-                    {% endfor %}
-                  {% endif %}
+              {% if nav_item.is_section %}
+                {% set subsection_path = nav_item.children[0].url %}
+                {% set description = nav_item.children[0].meta.description %}
+              {% else %}
+                {% set subsection_path = nav_item.url %}
+                {% if nav_item.meta %}
+                  {% set description = nav_item.meta.description %}
                 {% endif %}
-              </a>    
-            </div>
+              {% endif %}
+              {% if ".index" in page.url %}
+                {% set subsection_path = "/" + subsection_path %}
+              {% else %}
+                {% set subsection_path = subsection_path|replace(page.url, '') %}
+              {% endif %}
+
+              <div class="card">
+                <a href="{{ subsection_path }}">
+                  <h2 class="title">{{ nav_item.title }}</h2> 
+                  {% if not description == "" %}
+                    <p class="description">{{ description }}</p>
+                  {% else %}
+                    {% if nav_item.is_link %}
+                      {% if '#' in nav_item.url %}
+                        {% set nav_item_url = nav_item.url.split('#')[0] %}
+                      {% else %}
+                        {% set nav_item_url = nav_item.url %}
+                      {% endif %}
+
+                      {% if nav_item_url.startswith('/') %}
+                        {% set nav_item_url = nav_item_url[1:] %}
+                      {% endif %}
+
+                      {% for nav_child in nav.children %}
+                        {{ find_desc_for_linked_pages(nav_child, nav_item_url, description) }}
+                      {% endfor %}
+                    {% endif %}
+                  {% endif %}
+                </a>    
+              </div>
+            {% endif %}
           {% endfor %}
           </div>
         {% endif %}


### PR DESCRIPTION
This PR hides the releases section from the navigation, but allows there to be an index page for the releases page that is rendered like the rest of our index pages are. It essentially:

- Hides the Releases section from the left nav, but keeps the structure of the content in that directory in tact so it can be used to render the Releases section index page, so `/builders/build/releases` (with list of all the releases)
- Hides the Releases section from the index page of the Build section, so `/builders/build`

I debated doing this with CSS, but it doesn't look good when the item shows up then disappears. 

If you have questions about this, cause it's a weird one, let me know. Or suggestions to improve this flow would be great, but I didn't want to spend a whole lot of time on it as I don't know what the chances are of us needing another hidden section—I assume slim.

Goes with: https://github.com/moonbeam-foundation/moonbeam-docs/pull/882