### PR TITLE
preload the hero image on the home page

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -6,6 +6,10 @@
   {%- endif -%}
 {% endblock %}
 
+{% block extrahead %}
+  <link rel="preload" as="image" href="/assets/images/hero.webp">
+{% endblock %}
+
 {% block content %}
 <div class="home">
   <div class="row hero">


### PR DESCRIPTION
This PR applies a minor fix to improve the LCP on the home page by preloading the hero image. Tests show that this boosts the LCP by .3 seconds on average.