### PR TITLE
Fix moonbeam.css 404 issue

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -14,11 +14,6 @@
   ></script>
 {% endblock %}
 
-{% block styles %}
-	{{ super() }}
-  <link rel="stylesheet" href="{{ '/assets/stylesheets/moonbeam.css' | url }}">
-{% endblock %}
-
 {% block fonts %}
   {{ super() }}
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
On the live site right now, if you open the terminal, you'll see 404 errors for `moonbeam.css`. This PR fixes that by removing `moonbeam.css` from the `main.html` file. The `moonbeam.css` file gets pulled in from the `mkdocs.yml` file now (along with the `termynal.css` file.

Test this locally and with the `build-docs-site` repo