### PR TITLE
update banner link and add redirect for runtime 2800 page

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -41,5 +41,5 @@
 
 {% block announce %}
   <p>Block times are now 6 seconds on Moonbase Alpha thanks to asynchrounous backing!
-     Learn more about <a href="https://docs.moonbeam.network/builders/build/releases/runtime-2800/">async backing</a>.</p>
+     Learn more about <a href="https://forum.moonbeam.network/t/runtime-rt2801-schedule/1616/4">async backing</a>.</p>
 {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@
           'redirect_maps':
               'builders/build/canonical-contracts/precompiles/eth-mainnet.md': 'builders/pallets-precompiles/precompiles/eth-mainnet.md'
               'builders/build/eth-api/dev-env/truffle.md': 'builders/build/eth-api/dev-env/index.md'
+              'builders/build/releases/runtime-2800.md': 'https://forum.moonbeam.network/t/runtime-rt2801-schedule/1616/4'
               'builders/get-started/moonbase.md': 'builders/get-started/networks/moonbase.md'
               'builders/get-started/moonriver.md': 'builders/get-started/networks/moonriver.md'
               'builders/get-started/moonbeam.md': 'builders/get-started/networks/moonbeam.md'


### PR DESCRIPTION
This PR updates the async backing banner link to point to the overview of runtime 2800 on the Moonbeam Forum, which goes over some of the details of async backing. It also adds a redirect for the Runtime 2800 page that links back to the Moonbeam Forum page.

Goes with: https://github.com/moonbeam-foundation/moonbeam-docs/pull/890