### PR TITLE
preserve whitespace in termynal snippets

### DIFF
--- a/material-overrides/assets/stylesheets/termynal.css
+++ b/material-overrides/assets/stylesheets/termynal.css
@@ -40,6 +40,7 @@
     display: block;
     line-height: 1.25;
     overflow-wrap: break-word;
+    white-space-collapse: preserve;
 }
 
 [data-ty]:before {


### PR DESCRIPTION
This makes it so that whitespacing is preserved

Before:
<img width="794" alt="before-" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/5f233ee8-53ba-4609-a0db-82b20287d556">

After:
<img width="725" alt="after" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/37ea3952-73a9-4390-b072-ae94c03cdc47">