### PR TITLE
fix copyright section

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1453,6 +1453,18 @@ html .md-typeset details.function div.tabbed-set,
   }
 }
 
+@media screen and (max-width: 50.125em) {
+  .papermoon {
+    position: unset;
+    transform: none;
+  }
+
+  .md-footer-copyright {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
 @media screen and (max-width: 48.125em) {
   .md-footer-meta__inner.md-grid {
     width: 94%;
@@ -1469,6 +1481,7 @@ html .md-typeset details.function div.tabbed-set,
   .md-footer-social .network-links {
     margin: 0 auto 1em;
   }
+
   .hs-button {
     display: flex;
   }


### PR DESCRIPTION
This just fixes the copyright section of the footer on smaller screens

<img width="369" alt="Screenshot 2024-06-21 at 5 25 59 PM" src="https://github.com/papermoonio/moonbeam-mkdocs/assets/26533957/25101d63-6708-4f15-ba6b-3a603ed61db5">

(ignore my browser console at the bottom of the screenshot)