### PR TITLE
update the banner messaging for async backing on Moonriver

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -46,6 +46,6 @@
 {%- endblock -%} 
 
 {% block announce %}
-  <p>Thanks to asynchronous backing, 6-second block times are coming to Moonriver and Moonbeam in the next runtime upgrade!
+  <p>Thanks to asynchronous backing, 6-second block times are now available on Moonriver and will be coming to Moonbeam in the next runtime upgrade!
      Learn more about <a href="https://wiki.polkadot.network/docs/learn-async-backing">async backing</a>.</p>
 {% endblock %}


### PR DESCRIPTION
Update banner messaging now that 6s block times are here on Moonriver!