### PR TITLE
update banner - async backing for all networks

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -46,6 +46,6 @@
 {%- endblock -%} 
 
 {% block announce %}
-  <p>Thanks to asynchronous backing, 6-second block times are now available on Moonriver and will be coming to Moonbeam in the next runtime upgrade!
+  <p>Thanks to asynchronous backing, 6-second block times are now available on all Moonbeam networks!
      Learn more about <a href="https://wiki.polkadot.network/docs/learn-async-backing">async backing</a>.</p>
 {% endblock %}


### PR DESCRIPTION
This PR updates the async backing banner so it's applicable for all moonbeam networks