### PR TITLE
Adding chinese support for website elements

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -15,6 +15,7 @@ extra_css:
   - /assets/stylesheets/moonbeam.css
   - /assets/stylesheets/termynal.css
 theme:
+  language: zh
   name: material
   custom_dir: material-overrides
   favicon: /assets/images/favicon.webp


### PR DESCRIPTION
Adding language specification for chinese mkdoc.
This translates site elements such as: "search", "Next", "Prev" etc.