### PR TITLE
update styling for code titles

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -807,6 +807,11 @@ html .md-typeset details.function div.tabbed-set,
   box-shadow: none;
 }
 
+/* Styling of code snippet titles */
+.highlight span.filename {
+  border-bottom: var(--border-grid);
+}
+
 /* Styling to prevent code blocks from overlapping the Copy to Clipboard button */
 .md-typeset pre > code {
   white-space: break-spaces;


### PR DESCRIPTION
The previous border color wasn't showing up. So, this just adds the default border between the title and the code snippet.

<img width="790" alt="Screenshot 2024-08-12 at 9 22 48 PM" src="https://github.com/user-attachments/assets/7aadfd40-494c-43f1-a8d6-7883e54319b2">
