### PR TITLE
add redirects for historical updates and runtime upgrades

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,8 @@ plugins:
         builders/build/eth-api/dev-env/thirdweb.md: builders/ethereum/dev-env/thirdweb.md
         builders/build/eth-api/dev-env/waffle-mars.md: builders/ethereum/dev-env/waffle-mars.md
         builders/build/eth-api/index.md: builders/ethereum/index.md
+        builders/ethereum/historical-updates.md: builders/build/historical-updates.md
+        builders/ethereum/runtime-upgrades.md: builders/build/runtime-upgrades.md
         builders/json-rpc/debug-trace.md: builders/ethereum/json-rpc/debug-trace.md
         builders/json-rpc/eth-rpc.md: builders/ethereum/json-rpc/eth-rpc.md
         builders/json-rpc/index.md: builders/ethereum/json-rpc/index.md


### PR DESCRIPTION
We had two pages for runtime upgrades and historical updates, so I deleted the duplicate pages in this PR: https://github.com/moonbeam-foundation/moonbeam-docs/pull/993

So, this PR just redirects the duplicate to the remaining pages