### PR TITLE
Pillow upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.7.2
 mkdocs-redirects==1.2.1
 nltk==3.8.1
-Pillow==9.4.0
+Pillow==11.1.0
 Pygments==2.17.2
 pymdown-extensions==10.7
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ MarkupSafe==2.1.3
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-git-revision-date-localized-plugin==1.2.2
+mkdocs-jupyter==0.25.1
 mkdocs-macros-plugin==1.0.5
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.5.3


### PR DESCRIPTION
I upgraded Pillow to version 11.1 for compatibility with Python 3.13.