### PR TITLE
Update mkdocs configs and fix moving nav bar

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -251,17 +251,20 @@ body {
   max-width: 300px;
   padding: 0.467em 1em;
   z-index: 1;
-  display: none;
   align-items: center;
   border-radius: var(--border-radius);
   border: var(--border-width-thin) solid var(--light-transparent-15);
   background: var(--teal-dark-transparent-15);
   color: var(--teal-light);
   position: relative;
+  display: flex;
+  opacity: 0;
+  cursor: default;
 }
 
 .select-wrapper.display {
-  display: flex; /* Only display the selector if it has the display class */
+  opacity: 1;
+  cursor: pointer;
 }
 
 .select-wrapper .md-icon svg {

--- a/material-overrides/partials/header.html
+++ b/material-overrides/partials/header.html
@@ -16,12 +16,6 @@
           {% include "partials/tabs.html" %}
         {% endif %}
       {% endif %}
-      <a href="#" class="md-header__button md-button connectMetaMask-nav md-typeset">
-        Connect Wallet
-      </a>
-      <a class="md-header__button md-button faucet md-typeset" href="https://faucet.moonbeam.network/" target="_blank">
-        Faucet
-      </a>
       <div class="language-select-wrapper select-wrapper">
         <span class="language-select-label select-label">Eng</span>
         <ul class="language-select select">
@@ -33,6 +27,12 @@
           <span class="md-icon selector-open">{% include
             ".icons/material/chevron-up.svg" %}</span>
       </div>
+      <a href="#" class="md-header__button md-button connectMetaMask-nav md-typeset">
+        Connect Wallet
+      </a>
+      <a class="md-header__button md-button faucet md-typeset" href="https://faucet.moonbeam.network/" target="_blank">
+        Faucet
+      </a>
       {% if "material/search" in config["plugins"] %}
       <label class="md-header__button md-icon" for="__search">
         {% include ".icons/material/magnify.svg" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,6 @@ theme:
     - navigation.tabs.sticky
     - navigation.sections
     - navigation.indexes
-    - navigation.instant
     - navigation.prune
     - content.code.copy
     - announce.dismiss
@@ -60,7 +59,7 @@ plugins:
   - git-revision-date-localized:
       exclude:
         - .snippets/*
-      enabled: !ENV ENABLED_GIT_REVISION_DATE, True
+      enabled: !ENV [ENABLED_GIT_REVISION_DATE, True]
       enable_creation_date: true
   # - privacy
   - minify:


### PR DESCRIPTION
This PR does the following:

- Removes `navigation.instant` because there are some issues that it causes with loading JavaScript on each page
- Update the git-revision-date-localized plugin config so that when you use the `ENABLED_GIT_REVISION_DATE` variable, it actually works and disables the plugin
- The top nav bar was moving a bit depending on whether or not the page had a corresponding CN page. So this moves the language selector to the end and uses opacity to hide and show it so that the width of the button remains in-tact and the shifting no longer occurs