### PR TITLE
remove box shadow

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -500,6 +500,7 @@ a.md-nav__link:hover.md-nav__link--active:hover {
     > .md-nav__link:not(.md-nav__container),
   .md-nav__item--section > .md-nav__link:not(.md-nav__container) {
     pointer-events: auto;
+    box-shadow: none;
   }
 
   /* Remove arrow (dropdown) icon next to the section header (i.e., Builders, Node Operators, etc.) */


### PR DESCRIPTION
This removes the box shadow under the root-level section on the left nav.

Before:
<img width="342" alt="Screenshot 2025-02-19 at 10 41 50 PM" src="https://github.com/user-attachments/assets/61c26d9d-508d-468d-8dd8-0b280ca21e39" />

After:
<img width="312" alt="Screenshot 2025-02-19 at 10 41 55 PM" src="https://github.com/user-attachments/assets/dc182d38-9e09-49e0-a32b-21a742e89a9d" />