### PR TITLE
Add cookbook keyboard shortcut fail-safe

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -35,6 +35,19 @@
   </script>
 {% endblock %}
 
+{% block scripts %}
+  {{ super() }}
+  <script>
+    document.body.addEventListener('click', (event) => {
+      if (event.target.tagName === 'ASK-COOKBOOK') {
+        event.target.addEventListener('keydown', (event) => {
+          event.stopPropagation()
+        })
+      }
+    });
+  </script>
+{% endblock %}
+
 {% block fonts %}
   {{ super() }}
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Add a fail-safe script that prevents shortcuts when using the cookbook, especially when typing specific letters like n, f, or p. 