### PR TITLE
Add Grove to URL Ignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -9,4 +9,5 @@ https://polkadot.com/
 # Ignore Google Fonts service
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
+
 https://portal.grove.city/

--- a/.urlignore
+++ b/.urlignore
@@ -9,3 +9,4 @@ https://polkadot.com/
 # Ignore Google Fonts service
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
+https://portal.grove.city

--- a/.urlignore
+++ b/.urlignore
@@ -10,4 +10,5 @@ https://polkadot.com/
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
 
+# Ignore Grove RPC
 https://portal.grove.city/

--- a/.urlignore
+++ b/.urlignore
@@ -9,4 +9,4 @@ https://polkadot.com/
 # Ignore Google Fonts service
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
-https://portal.grove.city
+https://portal.grove.city/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include an additional URL for exclusion.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R12): Added `https://portal.grove.city` to the list of ignored URLs.update-grove-link