### PR TITLE
Update .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -9,3 +9,4 @@ https://polkadot.com/
 # Ignore Google Fonts service
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
+https://ethereum.org/


### PR DESCRIPTION
Update .urlignore - ethereum.org links fail the link checker but shouldn't
This pull request includes a small change to the `.urlignore` file. The change adds `https://ethereum.org/` to the list of ignored URLs.