### PR TITLE
Add urls to ignore for PR link checker

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -13,3 +13,4 @@ https://portal.grove.city/
 # Ignore websites that don't allow scrapers
 https://metamask.io/
 https://polkadot.com/
+https://x.com/

--- a/.urlignore
+++ b/.urlignore
@@ -3,9 +3,6 @@
 localhost
 127.0.0.1
 
-# Polkadot main site (404s - non-browser clients)
-https://polkadot.com/
-
 # Ignore Google Fonts service
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
@@ -15,3 +12,4 @@ https://portal.grove.city/
 
 # Ignore websites that don't allow scrapers
 https://metamask.io/
+https://polkadot.com/

--- a/.urlignore
+++ b/.urlignore
@@ -10,5 +10,8 @@ https://polkadot.com/
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
 
-# Ignore Grove RPC
+# Ignore websites that redirect too many times
 https://portal.grove.city/
+
+# Ignore websites that don't allow scrapers
+https://metamask.io/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to refine the list of URLs ignored during scraping by categorizing them more effectively. The changes include removing outdated comments and adding new URLs based on updated criteria.

### Updates to `.urlignore` file:

* Removed the comment about the Polkadot main site and reclassified `https://polkadot.com/` under websites that don't allow scrapers.
* Added new categories for ignored URLs: websites that redirect excessively (`https://portal.grove.city/`) and websites that disallow scrapers (`https://metamask.io/` and `https://polkadot.com/`).