### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -7,6 +7,9 @@ localhost
 https://fonts.gstatic.com/
 https://fonts.googleapis.com/
 
+# Ignore known working URLs
+https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub#newheads
+
 # Ignore websites that redirect too many times
 https://portal.grove.city/
 


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include a new URL that is known to be working, improving the clarity and maintainability of the ignored URLs list.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R10-R12): Added `https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub#newheads` to the list of ignored URLs under a new comment section for "known working URLs."