### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -14,3 +14,6 @@ https://portal.grove.city/
 https://metamask.io/
 https://polkadot.com/
 https://x.com/
+
+# Ignore known working URLs
+https://ethereum.org/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include a new URL for exclusion. The added URL is a known working link that doesn't need to be checked for issues. 

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R17-R19): Added `https://ethereum.org/` to the list of ignored URLs. This is a known working URL and is being excluded to streamline URL checks.