### PR TITLE
Brownie and Open Zeppelin Defender Redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -214,7 +214,11 @@
 	},
 	{
 	  "key":"/builders/build/eth-api/dev-env/brownie/",
-	  "value":"/builders/ethereum/dev-env/brownie/"
+	  "value":"/builders/ethereum/dev-env/ape/"
+	},
+	{
+	  "key":"/builders/ethereum/dev-env/brownie/",
+	  "value":"/builders/ethereum/dev-env/ape/"
 	},
 	{
 	  "key":"/builders/build/eth-api/dev-env/foundry/",
@@ -234,7 +238,11 @@
 	},
 	{
 	  "key":"/builders/build/eth-api/dev-env/openzeppelin/defender/",
-	  "value":"/builders/ethereum/dev-env/openzeppelin/defender/"
+	  "value":"/builders/ethereum/dev-env/openzeppelin/"
+	},
+		{
+	  "key":"/builders/ethereum/dev-env/openzeppelin/defender/",
+	  "value":"/builders/ethereum/dev-env/openzeppelin/"
 	},
 	{
 	  "key":"/builders/build/eth-api/dev-env/openzeppelin/",

--- a/redirects.json
+++ b/redirects.json
@@ -240,7 +240,7 @@
 	  "key":"/builders/build/eth-api/dev-env/openzeppelin/defender/",
 	  "value":"/builders/ethereum/dev-env/openzeppelin/"
 	},
-		{
+	{
 	  "key":"/builders/ethereum/dev-env/openzeppelin/defender/",
 	  "value":"/builders/ethereum/dev-env/openzeppelin/"
 	},


### PR DESCRIPTION
This pull request updates the `redirects.json` file to adjust and add redirections for Ethereum development environments. The changes standardize and simplify the redirection paths for tools like Brownie, Ape, and OpenZeppelin.

### Redirection updates:

* Updated the Brownie development environment redirection to point to the Ape development environment and added a new redirection for the Brownie path under Ethereum. (`[redirects.jsonL217-R221](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L217-R221)`)
* Updated the OpenZeppelin Defender redirection to point to a more generic OpenZeppelin path and added a new redirection for the Defender path under Ethereum. (`[redirects.jsonL237-R245](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L237-R245)`)