### PR TITLE
Remove Banner

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -31,10 +31,13 @@
   {%- endif -%} 
 {%- endblock -%} 
 
+{#- Uncomment the block below to add an announcement banner back to the site -#}
+{#
 {% block announce %}
   <p>As of Runtime 3400, the minimum gas price has been reduced by 4x to 31.25 Gwei. 
      Learn more about <a href="https://github.com/moonbeam-foundation/moonbeam/pull/3058">the new minimum gas price</a>.</p>
 {% endblock %}
+#}
 
 {% block site_nav %}
   {#- Navigation (left menu) -#}


### PR DESCRIPTION
Decomming the stale banner from Runtime 3400! 

This pull request adds a commented-out block to the `material-overrides/main.html` file, making it easier to re-enable an announcement banner in the future if needed. There are no functional changes to the site at this time.

