### PR TITLE
Add cache_safe to Minify

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ plugins:
       minify_html: true
       minify_js: true
       minify_css: true
+      cache_safe: true
       js_files:
         - js/connectMetaMask.js
         - js/errorModal.js


### PR DESCRIPTION
This pull request makes a minor configuration update to the `mkdocs.yml` file, specifically in the plugins section.

* Added the `cache_safe: true` option to the `plugins` configuration in `mkdocs.yml`, which may help ensure safer caching of generated site assets.

For this to work, we need to merge this PR first: https://github.com/papermoonio/workflows/pull/16