### PR TITLE
Razor Network Oracles Redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -551,6 +551,10 @@
 	{
 	  "key": "/node-operators/oracle-nodes/",
 	  "value": "/builders/integrations/oracles/"
+	},
+	{
+	  "key": "/builders/integrations/oracles/razor-network/",
+	  "value": "/builders/integrations/oracles/"
 	}
   ]
 }


### PR DESCRIPTION
This pull request makes a minor update to the `redirects.json` file, adding a new redirect for the Razor Network oracle integration. The change ensures that requests to the Razor Network oracle documentation are redirected to the main oracles integrations page.

* Added a redirect from `/builders/integrations/oracles/razor-network/` to `/builders/integrations/oracles/` in `redirects.json`.