### PR TITLE
decom web3js

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -101,6 +101,10 @@
       "value": "/builders/ethereum/libraries/"
     },
     {
+      "key": "/cn/builders/libraries/web3js/",
+      "value": "/cn/builders/libraries/"
+    },
+    {
       "key": "/builders/ethereum/libraries/web3js/",
       "value": "/builders/ethereum/libraries/"
     },

--- a/redirects.json
+++ b/redirects.json
@@ -98,7 +98,11 @@
     },
     {
       "key": "/builders/build/eth-api/libraries/web3js/",
-      "value": "/builders/ethereum/libraries/web3js/"
+      "value": "/builders/ethereum/libraries/"
+    },
+    {
+      "key": "/builders/ethereum/libraries/web3js/",
+      "value": "/builders/ethereum/libraries/"
     },
     {
       "key": "/builders/build/eth-api/libraries/web3py/",


### PR DESCRIPTION
This pull request updates the redirect logic for Ethereum library documentation to ensure URLs for `web3js` are correctly routed to the general libraries page. The changes help prevent broken links and improve navigation consistency.

URL redirect updates:

* Updated the redirect for `/builders/build/eth-api/libraries/web3js/` to point to `/builders/ethereum/libraries/` instead of the more specific `web3js` page.
* Added a new redirect for `/builders/ethereum/libraries/web3js/` to also point to `/builders/ethereum/libraries/`, consolidating references to the general libraries page.