### PR TITLE
decom integ

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -213,6 +213,18 @@
       "value": "/builders/get-started/networks/"
     },
     {
+      "key": "/builders/integrations/analytics/dapplooker/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/analytics/zapper/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/indexers/moralis/",
+      "value": "/builders/integrations/"
+    },
+    {
       "key": "/builders/integrations/gaming/metafab/",
       "value": "/builders/integrations/"
     },

--- a/redirects.json
+++ b/redirects.json
@@ -241,6 +241,26 @@
       "value": "/builders/get-started/networks/"
     },
     {
+      "key": "/builders/integrations/wallets/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/metamask/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/particle-network/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/rainbowkit/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/walletconnect/",
+      "value": "/builders/integrations/"
+    },
+    {
       "key": "/builders/integrations/gaming/metafab/",
       "value": "/builders/integrations/"
     },

--- a/redirects.json
+++ b/redirects.json
@@ -213,6 +213,10 @@
       "value": "/builders/get-started/networks/"
     },
     {
+      "key": "/builders/integrations/analytics/",
+      "value": "/builders/integrations/"
+    },
+    {
       "key": "/builders/integrations/analytics/dapplooker/",
       "value": "/builders/integrations/"
     },
@@ -221,11 +225,11 @@
       "value": "/builders/integrations/"
     },
     {
-      "key": "/builders/integrations/indexers/moralis/",
+      "key": "/builders/integrations/gaming/metafab/",
       "value": "/builders/integrations/"
     },
     {
-      "key": "/builders/integrations/gaming/metafab/",
+      "key": "/builders/integrations/indexers/moralis/",
       "value": "/builders/integrations/"
     },
     {


### PR DESCRIPTION
This pull request adds new redirect rules to the `redirects.json` file, improving navigation for several builder integration pages by directing them to a more general integrations section.

Redirects for analytics and indexer integrations:

* Added a redirect from `/builders/integrations/analytics/dapplooker/` to `/builders/integrations/`.
* Added a redirect from `/builders/integrations/analytics/zapper/` to `/builders/integrations/`.
* Added a redirect from `/builders/integrations/indexers/moralis/` to `/builders/integrations/`.