### PR TITLE
wallets redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -213,6 +213,30 @@
       "value": "/builders/get-started/networks/"
     },
     {
+      "key": "/builders/integrations/wallets/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/index/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/metamask/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/particle-network/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/rainbowkit/",
+      "value": "/builders/integrations/"
+    },
+    {
+      "key": "/builders/integrations/wallets/walletconnect/",
+      "value": "/builders/integrations/"
+    },
+    {
       "key": "/builders/integrations/gaming/metafab/",
       "value": "/builders/integrations/"
     },

--- a/redirects.json
+++ b/redirects.json
@@ -217,10 +217,6 @@
       "value": "/builders/integrations/"
     },
     {
-      "key": "/builders/integrations/wallets/index/",
-      "value": "/builders/integrations/"
-    },
-    {
       "key": "/builders/integrations/wallets/metamask/",
       "value": "/builders/integrations/"
     },


### PR DESCRIPTION
This pull request adds several new redirect rules to the `redirects.json` file, specifically targeting wallet integration documentation URLs. These changes help ensure that outdated or specific wallet-related paths correctly redirect to the general integrations page, improving navigation and reducing broken links.

Redirects for wallet integrations:

* Added redirects from `/builders/integrations/wallets/`, `/builders/integrations/wallets/index/`, and several wallet-specific paths (`metamask`, `particle-network`, `rainbowkit`, `walletconnect`) to `/builders/integrations/` to consolidate wallet integration documentation under a single page.