### PR TITLE
substrate gov pallet redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -153,6 +153,26 @@
       "value": "/builders/substrate/libraries/sidecar/"
     },
     {
+      "key": "/builders/substrate/interfaces/features/governance/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/governance/conviction-voting/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/governance/parameters/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/governance/preimage/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/governance/referenda/",
+      "value": "/builders/substrate/"
+    },
+    {
       "key": "/builders/ethereum/dev-env/brownie/",
       "value": "/builders/ethereum/dev-env/ape/"
     },
@@ -318,7 +338,7 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/conviction-voting/",
-      "value": "/builders/substrate/interfaces/features/governance/conviction-voting/"
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/pallets/identity/",
@@ -330,7 +350,7 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/preimage/",
-      "value": "/builders/substrate/interfaces/features/governance/preimage/"
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/pallets/proxy/",
@@ -342,7 +362,7 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/referenda/",
-      "value": "/builders/substrate/interfaces/features/governance/referenda/"
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/pallets/staking/",


### PR DESCRIPTION
This pull request updates the `redirects.json` file to simplify and consolidate several Substrate governance-related redirects. The main goal is to ensure that various URLs related to governance features and pallets consistently redirect to the main Substrate builders page, improving navigation and reducing fragmentation.

Redirect consolidation for governance features:

* Added new redirects for specific governance feature URLs (such as `conviction-voting`, `parameters`, `preimage`, and `referenda`) under `/builders/substrate/interfaces/features/governance/` to point to `/builders/substrate/`.

Redirect consolidation for pallets:

* Updated redirects for the `conviction-voting`, `preimage`, and `referenda` pallets under `/builders/pallets-precompiles/pallets/` to point directly to `/builders/substrate/` instead of their previous, more specific governance feature URLs. [[1]](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L321-R341) [[2]](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L333-R353) [[3]](diffhunk://#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L345-R365)