### PR TITLE
substrate feature redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -353,7 +353,7 @@
       "value": "/builders/substrate/interfaces/utility/utility/"
     },
     {
-      "key": "/builders/substrate/interfaces/features/index/",
+      "key": "/builders/substrate/interfaces/features/",
       "value": "/builders/substrate/"
     },
     {

--- a/redirects.json
+++ b/redirects.json
@@ -338,7 +338,7 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/randomness/",
-      "value": "/builders/substrate/interfaces/features/randomness/"
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/pallets/referenda/",
@@ -346,11 +346,23 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/staking/",
-      "value": "/builders/substrate/interfaces/features/staking/"
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/pallets/utility/",
       "value": "/builders/substrate/interfaces/utility/utility/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/index/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/randomness/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/features/staking/",
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/precompiles/",


### PR DESCRIPTION
This pull request updates the redirect mappings in `redirects.json` to simplify and consolidate several Substrate-related paths. The main focus is to redirect various feature-specific URLs to a broader Substrate overview page, streamlining navigation and reducing the number of granular redirects.

Redirect simplification and consolidation:

* Changed the redirect targets for `/builders/pallets-precompiles/pallets/randomness/` and `/builders/pallets-precompiles/pallets/staking/` to point to `/builders/substrate/` instead of their previous feature-specific destinations.
* Added new redirects so that `/builders/substrate/interfaces/features/`, `/builders/substrate/interfaces/features/randomness/`, and `/builders/substrate/interfaces/features/staking/` all point to `/builders/substrate/`.