### PR TITLE
utility redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -350,7 +350,19 @@
     },
     {
       "key": "/builders/pallets-precompiles/pallets/utility/",
-      "value": "/builders/substrate/interfaces/utility/utility/"
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/interoperability/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/utility/",
+      "value": "/builders/substrate/"
+    },
+    {
+      "key": "/builders/substrate/interfaces/utility/utility/",
+      "value": "/builders/substrate/"
     },
     {
       "key": "/builders/pallets-precompiles/precompiles/",


### PR DESCRIPTION
This pull request updates the `redirects.json` file to simplify the URL structure for several Substrate-related documentation paths. The main change is consolidating multiple specific interface and utility paths to a single, more general Substrate builders page.

Redirect simplification:

* Changed the redirect for `/builders/pallets-precompiles/pallets/utility/` from `/builders/substrate/interfaces/utility/utility/` to `/builders/substrate/`, streamlining navigation.
* Added new redirects for `/builders/substrate/interfaces/interoperability/`, `/builders/substrate/interfaces/utility/`, and `/builders/substrate/interfaces/utility/utility/` to point to `/builders/substrate/`, further consolidating related documentation paths.