### PR TITLE
learn 3 redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -542,7 +542,7 @@
     },
     {
       "key": "/learn/platform/roadmap/",
-      "value": "/"
+      "value": "/learn/"
     },
     {
       "key": "/learn/unified-accounts/",

--- a/redirects.json
+++ b/redirects.json
@@ -525,6 +525,10 @@
       "value": "/learn/core-concepts/unified-accounts/"
     },
     {
+      "key": "/learn/platform/roadmap/",
+      "value": "/"
+    },
+    {
       "key": "/learn/platform/technology/",
       "value": "/learn/"
     },
@@ -539,10 +543,6 @@
     {
       "key": "/learn/platform/why-polkadot/",
       "value": "/learn/"
-    },
-    {
-      "key": "/learn/platform/roadmap/",
-      "value": "/"
     },
     {
       "key": "/learn/unified-accounts/",

--- a/redirects.json
+++ b/redirects.json
@@ -525,6 +525,22 @@
       "value": "/learn/core-concepts/unified-accounts/"
     },
     {
+      "key": "/learn/platform/technology/",
+      "value": "/learn/"
+    },
+    {
+      "key": "/learn/platform/tokens/",
+      "value": "/learn/"
+    },
+    {
+      "key": "/learn/platform/vision/",
+      "value": "/learn/"
+    },
+    {
+      "key": "/learn/platform/why-polkadot/",
+      "value": "/learn/"
+    },
+    {
       "key": "/learn/platform/roadmap/",
       "value": "/"
     },


### PR DESCRIPTION
This pull request adds several new redirects to the `redirects.json` file, ensuring that outdated or deprecated platform-related URLs now point to the main `/learn/` page. This helps users find relevant information more easily when visiting old platform documentation links.

Redirect additions:

* Added redirects for `/learn/platform/technology/`, `/learn/platform/tokens/`, `/learn/platform/vision/`, and `/learn/platform/why-polkadot/` to `/learn/`.