### PR TITLE
Mathwallet and graph redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -501,10 +501,6 @@
       "value": "/builders/ethereum/dev-env/"
     },
     {
-      "key": "/tokens/connect/mathwallet/",
-      "value": "/tokens/connect/"
-    },
-    {
       "key": "/integrations/openzeppelin/overview/",
       "value": "/builders/ethereum/dev-env/openzeppelin/overview/"
     },
@@ -563,6 +559,10 @@
     {
       "key": "/node-operators/oracle-nodes/node-chainlink/",
       "value": "/builders/integrations/oracles/"
+    },
+    {
+      "key": "/tokens/connect/mathwallet/",
+      "value": "/tokens/connect/"
     },
     {
       "key": "/tutorials/eth-api/truffle-start-to-end/",

--- a/redirects.json
+++ b/redirects.json
@@ -217,6 +217,10 @@
       "value": "/builders/integrations/"
     },
     {
+      "key": "/builders/integrations/indexers/thegraph/",
+      "value": "/builders/integrations/"
+    },
+    {
       "key": "/builders/integrations/oracles/band-protocol/",
       "value": "/builders/integrations/oracles/"
     },
@@ -495,6 +499,10 @@
     {
       "key": "/getting-started/using-truffle/",
       "value": "/builders/ethereum/dev-env/"
+    },
+    {
+      "key": "/tokens/connect/mathwallet/",
+      "value": "/tokens/connect/"
     },
     {
       "key": "/integrations/openzeppelin/overview/",


### PR DESCRIPTION
This pull request adds new redirect rules to the `redirects.json` file to ensure users are directed to the correct integration and token connection pages. These changes help maintain proper navigation and user experience after URL changes.

Redirect additions:

* Added a redirect from `/builders/integrations/indexers/thegraph/` to `/builders/integrations/` to handle requests for The Graph indexer integration.
* Added a redirect from `/tokens/connect/mathwallet/` to `/tokens/connect/` to properly route MathWallet connection requests.