### PR TITLE
Add Dia Redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -289,6 +289,10 @@
       "value": "/builders/integrations/oracles/"
     },
     {
+      "key": "/builders/integrations/oracles/dia/",
+      "value": "/builders/integrations/oracles/"
+    },
+    {
       "key": "/builders/integrations/oracles/razor-network/",
       "value": "/builders/integrations/oracles/"
     },


### PR DESCRIPTION
This pull request adds a new redirect to the `redirects.json` file to ensure users visiting the DIA oracle integration page are properly redirected to the general oracles integrations page.

* Redirects update:
  * Added a redirect from `/builders/integrations/oracles/dia/` to `/builders/integrations/oracles/` in `redirects.json`.