### PR TITLE
Update robots txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,27 @@
-User-agent: * 
+# Search engine crawlers - block from /ai/ to prevent indexing raw markdown/JSONL
 
+User-agent: Googlebot
+Disallow: /ai/
+
+User-agent: Bingbot
+Disallow: /ai/
+
+User-agent: Yandexbot
+Disallow: /ai/
+
+User-agent: Baiduspider
+Disallow: /ai/
+
+User-agent: DuckDuckBot
+Disallow: /ai/
+
+User-agent: Applebot
+Disallow: /ai/
+
+User-agent: Sogou
+Disallow: /ai/
+
+# All other agents (including AI/LLM agents) - no restrictions
+
+User-agent: *
 Sitemap: https://docs.moonbeam.network/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,46 @@
+# All bots: allow everything by default
+
 User-agent: *
+Disallow:
+
+# Search engines: block /ai/ to prevent duplicate content
+# and raw markdown from appearing in search results
+
+User-agent: Googlebot
+Disallow: /ai/
+
+User-agent: Bingbot
+Disallow: /ai/
+
+User-agent: Yandex
+Disallow: /ai/
+
+# Training-specific crawlers: block entire site
+# These crawl for model training, NOT for user-initiated requests
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+# Older Anthropic crawler, mostly deprecated
+
+User-agent: anthropic-ai
+Disallow: /
 
 Sitemap: https://docs.moonbeam.network/sitemap.xml
+
+# User-facing LLM agents (ChatGPT-User, ClaudeBot, etc.)
+# are NOT blocked — they use the default "allow all" rule.
+# Blocking these would prevent users from pasting a docs URL
+# into ChatGPT/Claude and asking questions about it.

--- a/robots.txt
+++ b/robots.txt
@@ -1,27 +1,3 @@
-# Search engine crawlers - block from /ai/ to prevent indexing raw markdown/JSONL
-
-User-agent: Googlebot
-Disallow: /ai/
-
-User-agent: Bingbot
-Disallow: /ai/
-
-User-agent: Yandexbot
-Disallow: /ai/
-
-User-agent: Baiduspider
-Disallow: /ai/
-
-User-agent: DuckDuckBot
-Disallow: /ai/
-
-User-agent: Applebot
-Disallow: /ai/
-
-User-agent: Sogou
-Disallow: /ai/
-
-# All other agents (including AI/LLM agents) - no restrictions
-
 User-agent: *
+
 Sitemap: https://docs.moonbeam.network/sitemap.xml


### PR DESCRIPTION
Using Disallow: /ai/ was keeping user-based agent bots like Claude and ChatGPT from being able to access the LLM markdown files intended for their use. For now, we can remove all Disallow statements as Google doesn't index Markdown files at all so there is no concern around search results serving the MD rather than HTML version of pages to users. 