### PR TITLE
Reorder AI Plugins to support token counts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,12 +71,12 @@ exclude_docs: README.md
 plugins:
   - search
   - awesome-nav
+  - resolve_md:
+      llms_config: llms_config.json
+      enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
   - ai_resources_page:
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
   - ai_page_actions:
-      enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
-  - resolve_md:
-      llms_config: llms_config.json
       enabled: !ENV [ENABLED_LLMS_PLUGINS, True]
   - glightbox
   - git-revision-date-localized:


### PR DESCRIPTION
This change must ship before this PR will work properly: https://github.com/papermoonio/mkdocs-plugins/pull/20

resolve_md has to be first for the token count manifest to generate at the right time for the values to appear in the AI Resources table. 

<img width="852" height="273" alt="mb-token-counts" src="https://github.com/user-attachments/assets/530dca7d-79a6-41ed-97db-924c247d1c60" />
