### PR TITLE
add plugin snippet resolver

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ plugins:
   - macros:
       include_yaml:
         - moonbeam-docs/variables.yml
+  - snippet_var_resolver
   - social:
       enabled: !ENV [SOCIAL_CARDS, True]
       cards_layout_dir: layouts


### PR DESCRIPTION
This pull request updates `mkdocs.yml` by adding a new plugin to the documentation build process.

Plugin configuration:

* Added the `snippet_var_resolver` plugin to the `plugins` section in `mkdocs.yml`, which will enable variable resolution in documentation snippets.

This needs to be merged with this one: https://github.com/moonbeam-foundation/moonbeam-docs/pull/1438