### PR TITLE
Remove outdated URLs from the codebase

### DIFF
--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -25,10 +25,6 @@
           <button class="pink-primary-button md-button">Start Building <span class="md-icon">{% include
               ".icons/material/arrow-right.svg" %}</span></button>
         </a>
-        <a href="https://immunefi.com/bug-bounty/moonbeamnetwork/information/">
-          <button class="pink-secondary-button md-button">Bug Bounty <span class="md-icon">{% include
-              ".icons/material/arrow-right.svg" %}</span></button>
-        </a>
         <a href="https://moonbeam.network/build/grants">
           <button class="pink-secondary-button md-button">Grants Program <span class="md-icon">{% include
               ".icons/material/arrow-right.svg" %}</span></button>
@@ -66,10 +62,6 @@
     <div class="row hero-buttons">
       <a href="/builders/get-started/">
         <button class="pink-primary-button md-button">Start Building <span class="md-icon">{% include
-            ".icons/material/arrow-right.svg" %}</span></button>
-      </a>
-      <a href="https://immunefi.com/bug-bounty/moonbeamnetwork/information/">
-        <button class="pink-secondary-button md-button">Bug Bounty <span class="md-icon">{% include
             ".icons/material/arrow-right.svg" %}</span></button>
       </a>
       <a href="https://moonbeam.network/build/grants">

--- a/mkdocs-cn/material-overrides/home.html
+++ b/mkdocs-cn/material-overrides/home.html
@@ -20,10 +20,6 @@
           <button class="md-button">开始搭建<span class="md-icon">{% include
               ".icons/material/arrow-right.svg" %}</span></button>
         </a>
-        <a href="https://immunefi.com/bug-bounty/moonbeamnetwork/information/">
-          <button class="md-button">Bug Bounty赏金计划<span class="md-icon">{% include
-              ".icons/material/arrow-right.svg" %}</span></button>
-        </a>
         <a href="https://moonbeam.network/build/grants">
           <button class="md-button">Grants加速计划<span class="md-icon">{% include
               ".icons/material/arrow-right.svg" %}</span></button>
@@ -58,10 +54,6 @@
     <div class="row hero-buttons">
       <a href="/builders/get-started/">
         <button class="md-button">开始搭建<span class="md-icon">{% include
-            ".icons/material/arrow-right.svg" %}</span></button>
-      </a>
-      <a href="https://immunefi.com/bug-bounty/moonbeamnetwork/information/">
-        <button class="md-button">Bug Bounty赏金计划<span class="md-icon">{% include
             ".icons/material/arrow-right.svg" %}</span></button>
       </a>
       <a href="https://moonbeam.network/build/grants">


### PR DESCRIPTION
This pull request removes the "Bug Bounty" button and its associated link from both the English and Chinese versions of the homepage. 

Content updates:

* Removed the "Bug Bounty" button and link from the English homepage (`material-overrides/home.html`). [[1]](diffhunk://#diff-8022bfde129910441b6eefb8239ae5cf93361d79cb643248f3f5b99506709999L28-L31) [[2]](diffhunk://#diff-8022bfde129910441b6eefb8239ae5cf93361d79cb643248f3f5b99506709999L71-L74)
* Removed the "Bug Bounty赏金计划" button and link from the Chinese homepage (`mkdocs-cn/material-overrides/home.html`). [[1]](diffhunk://#diff-f512aab97c90492f0d455f1dbecaeb4a94975fbe13d39fbc4d0913ae8e5d8805L23-L26) [[2]](diffhunk://#diff-f512aab97c90492f0d455f1dbecaeb4a94975fbe13d39fbc4d0913ae8e5d8805L63-L66)

resolves https://github.com/moonbeam-foundation/moonbeam-docs/issues/1474, 
resolves https://github.com/moonbeam-foundation/moonbeam-docs/issues/1476