### PR TITLE
Add url to urlingnore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -14,6 +14,7 @@ https://x.com/
 
 # Ignore known working URLs
 https://ethereum.org/
+https://geth.ethereum.org/
 https://moonbase-minterc20.netlify.app/
 https://moonbeam-explorer.netlify.app/
 


### PR DESCRIPTION
This pull request adds a new URL to the `.urlignore` file to prevent it from being flagged during URL checks.

- URL ignore list update:
  * Added `https://geth.ethereum.org/` to `.urlignore` to ignore this known working URL during automated checks.
  
  
  Resolves https://github.com/moonbeam-foundation/moonbeam-docs/issues/1477
  Resolves https://github.com/moonbeam-foundation/moonbeam-docs/issues/1478